### PR TITLE
hide the square tiles on top row on mobile

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -561,7 +561,10 @@ hr {
     margin-top: 0;
     padding: 15px 10px;
     min-width: 40px; }
-
+    
+.invi {
+  background: #bbada0;
+}
   .heading {
     margin-bottom: 10px; }
 


### PR DESCRIPTION
As per desktop version, the mobile version should also hide the top row tiles
